### PR TITLE
Add getMultipleClaimStatusAccounts

### DIFF
--- a/src/gumdrop.ts
+++ b/src/gumdrop.ts
@@ -84,7 +84,7 @@ export const getClaimStatusAccount = async (
   distributor: web3.PublicKey,
   programId: web3.PublicKey = GUMDROP_DISTRIBUTOR_ID
 ): Promise<ClaimStatusAccount | null> => {
-  // Wallet not required to query player faction accounts
+  // Wallet not required to query accounts
   const provider = new Provider(connection, null, null);
   const program = new Program(gumDropIdl as Idl, programId, provider);
   const claimStatusResult = await getClaimStatusKey(
@@ -118,7 +118,7 @@ export const getMultipleClaimStatusAccounts = async (
   distributor: web3.PublicKey,
   programId: web3.PublicKey = GUMDROP_DISTRIBUTOR_ID
 ): Promise<Array<ClaimStatusAccount | null>> => {
-  // Wallet not required to query player faction accounts
+  // Wallet not required to query accounts
   const provider = new Provider(connection, null, null);
   const program = new Program(gumDropIdl as Idl, programId, provider);
   const claimStatusKeys: web3.PublicKey[] = [];

--- a/src/gumdrop.ts
+++ b/src/gumdrop.ts
@@ -121,17 +121,13 @@ export const getMultipleClaimStatusAccounts = async (
   // Wallet not required to query accounts
   const provider = new Provider(connection, null, null);
   const program = new Program(gumDropIdl as Idl, programId, provider);
-  const claimStatusKeys: web3.PublicKey[] = [];
 
-  for (let index = 0; index < indexArray.length; index++) {
-    const element = indexArray[index];
-    const claimStatusResult = await getClaimStatusKey(
-      element,
-      distributor,
-      programId
-    );
-    claimStatusKeys.push(claimStatusResult[0]);
-  }
+  const claimStatusPromises = indexArray.map((it) => {
+    return getClaimStatusKey(it, distributor, programId);
+  });
+  const claimStatusKeys = (await Promise.all(claimStatusPromises)).map(
+    (it) => it[0]
+  );
 
   const accounts = await program.account.claimStatus.fetchMultiple(
     claimStatusKeys


### PR DESCRIPTION
## Changes

Adds a function that can fetch multiple claim status accounts for a distributor at once.

## Checklist

- [ ] UAT
- [ ] Passes final QA checks
