### PR TITLE
Use "browser" instead of "main" entrypoint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/staratlasmeta/factory/issues"
   },
   "homepage": "https://github.com/staratlasmeta/factory#readme",
-  "main": "dist/index.js",
+  "browser": "dist/index.js",
   "source": "src/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Changes

Per package.json [docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#browser),
> If your module is meant to be used client-side the browser field should be used instead of the main field.

## Checklist

- [ ] UAT
- [ ] Passes final QA checks
