### PR TITLE
Add a local module for AnchorTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@project-serum/anchor": "^0.24.2",
-        "@saberhq/anchor-contrib": "^1.12.64",
         "@solana/spl-token": "^0.1.8",
         "@solana/web3.js": "^1.15.0",
         "bn.js": "^5.1.3",
@@ -1477,41 +1476,6 @@
         "@solana/web3.js": "^1.2.0"
       }
     },
-    "node_modules/@saberhq/anchor-contrib": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@saberhq/anchor-contrib/-/anchor-contrib-1.13.1.tgz",
-      "integrity": "sha512-ZiZAqiQLTpFU43zQfLyoEkJjt+0LW5ZSm63wqc7xm0hKOw/ronMkNOslqXbNqIp2rRRg8GzOFgid4TAEWqzuOw==",
-      "dependencies": {
-        "@saberhq/solana-contrib": "^1.13.1",
-        "eventemitter3": "^4.0.7",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.mapvalues": "^4.6.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@project-serum/anchor": "^0.22 || ^0.23 || ^0.24",
-        "@solana/web3.js": "^1.37",
-        "bn.js": "^4 || ^5"
-      }
-    },
-    "node_modules/@saberhq/solana-contrib": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@saberhq/solana-contrib/-/solana-contrib-1.13.1.tgz",
-      "integrity": "sha512-2hWKZS8bhH1QXVzkf0OoMDdNDc/POCUUbKQEGwZBv+ri/9GUkfihYm6TPgVecmqa6PM1qMtUDGqrC529Pi/4mQ==",
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@types/promise-retry": "^1.1.3",
-        "@types/retry": "^0.12.2",
-        "promise-retry": "^2.0.1",
-        "retry": "^0.13.1",
-        "tiny-invariant": "^1.2.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.37",
-        "bn.js": "^4 || ^5"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1803,14 +1767,6 @@
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
     },
-    "node_modules/@types/promise-retry": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
-      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
-      "dependencies": {
-        "@types/retry": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -1820,11 +1776,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3146,11 +3097,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -6699,21 +6645,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "peer": true
-    },
-    "node_modules/lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7412,26 +7348,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/promise-retry/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7592,14 +7508,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -8239,11 +8147,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -9924,32 +9827,6 @@
         "buffer-layout": "^1.2.0"
       }
     },
-    "@saberhq/anchor-contrib": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@saberhq/anchor-contrib/-/anchor-contrib-1.13.1.tgz",
-      "integrity": "sha512-ZiZAqiQLTpFU43zQfLyoEkJjt+0LW5ZSm63wqc7xm0hKOw/ronMkNOslqXbNqIp2rRRg8GzOFgid4TAEWqzuOw==",
-      "requires": {
-        "@saberhq/solana-contrib": "^1.13.1",
-        "eventemitter3": "^4.0.7",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.mapvalues": "^4.6.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "@saberhq/solana-contrib": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@saberhq/solana-contrib/-/solana-contrib-1.13.1.tgz",
-      "integrity": "sha512-2hWKZS8bhH1QXVzkf0OoMDdNDc/POCUUbKQEGwZBv+ri/9GUkfihYm6TPgVecmqa6PM1qMtUDGqrC529Pi/4mQ==",
-      "requires": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@types/promise-retry": "^1.1.3",
-        "@types/retry": "^0.12.2",
-        "promise-retry": "^2.0.1",
-        "retry": "^0.13.1",
-        "tiny-invariant": "^1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -10214,14 +10091,6 @@
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
     },
-    "@types/promise-retry": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
-      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
-      "requires": {
-        "@types/retry": "*"
-      }
-    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -10231,11 +10100,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
-    "@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -11198,11 +11062,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13863,21 +13722,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "peer": true
-    },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -14418,22 +14267,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "requires": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "dependencies": {
-        "retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-        }
-      }
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -14541,11 +14374,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
-    },
-    "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -15015,11 +14843,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@project-serum/anchor": "^0.24.2",
-    "@saberhq/anchor-contrib": "^1.12.64",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "^1.15.0",
     "bn.js": "^5.1.3",

--- a/src/anchor/types.ts
+++ b/src/anchor/types.ts
@@ -1,0 +1,253 @@
+/**
+ * This code has been entirely taken from the excellent Saber-HQ anchor-contrib
+ * https://github.com/saber-hq/saber-common/tree/master/packages/anchor-contrib
+ *
+ * We chose to house just this code here because the development pace of anchor-contrib
+ * and its dependencies kept breaking our tests.  Since we only use the following code from
+ * that package, we decided to temporarily reference it here.
+ */
+import type {
+  AccountClient,
+  Address,
+  BN,
+  Context as AnchorContext,
+  Program as AProgram,
+  ProgramAccount,
+  StateClient,
+} from '@project-serum/anchor';
+import type {
+  Idl,
+  IdlAccountItem,
+  IdlAccounts,
+  IdlEvent,
+  IdlEventField,
+  IdlField,
+  IdlInstruction,
+  IdlType,
+  IdlTypeDef,
+  IdlTypeDefTyStruct,
+} from '@project-serum/anchor/dist/esm/idl';
+import type {
+  AccountMeta,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  TransactionSignature,
+} from '@solana/web3.js';
+
+type InstructionsParsed = Record<
+  string,
+  {
+    accounts: IdlAccountItem[];
+    args: Array<unknown>;
+  }
+>;
+
+export type ContextAccounts<A extends IdlAccountItem[]> = {
+  [K in A[number]['name']]: A[number] & { name: K } extends IdlAccounts
+    ? ContextAccounts<
+        NonNullable<(A[number] & { name: K } & IdlAccounts)['accounts']>
+      >
+    : Address;
+};
+
+type Context<A extends IdlAccountItem[]> = Omit<AnchorContext, 'accounts'> & {
+  accounts: ContextAccounts<A>;
+};
+
+type MakeInstructionsNamespace<
+  R extends InstructionsParsed,
+  Ret,
+  Mk extends { [M in keyof R]: unknown } = { [M in keyof R]: unknown }
+> = {
+  [M in keyof R]: ((
+    ...args: [...R[M]['args'], Context<R[M]['accounts']>]
+  ) => Ret) &
+    Mk[M];
+};
+
+type RpcNamespace<R extends InstructionsParsed> = MakeInstructionsNamespace<
+  R,
+  Promise<TransactionSignature>
+>;
+
+type InstructionNamespace<R extends InstructionsParsed> =
+  MakeInstructionsNamespace<
+    R,
+    TransactionInstruction,
+    {
+      [M in keyof R]: {
+        accounts: (ctx: ContextAccounts<R[M]['accounts']>) => AccountMeta[];
+      };
+    }
+  >;
+
+type TransactionNamespace<R extends InstructionsParsed> =
+  MakeInstructionsNamespace<R, Transaction>;
+
+type AccountsNamespace<A> = {
+  [K in keyof A]: Omit<
+    AccountClient,
+    'fetch' | 'fetchNullable' | 'all' | 'associated'
+  > & {
+    /**
+     * Returns a deserialized account.
+     *
+     * @param address The address of the account to fetch.
+     */
+    fetch: (address: PublicKey) => Promise<A[K]>;
+    /**
+     * Returns a deserialized account, returning null if it doesn't exist.
+     *
+     * @param address The address of the account to fetch.
+     */
+    fetchNullable: (address: PublicKey) => Promise<A[K] | null>;
+    /**
+     * Returns all instances of this account type for the program.
+     */
+    all: (
+      ...args: Parameters<AccountClient['all']>
+    ) => Promise<ProgramAccount<A[K]>[]>;
+    /**
+     * @deprecated since version 14.0.
+     *
+     * Function returning the associated account. Args are keys to associate.
+     * Order matters.
+     */
+    associated: (...args: PublicKey[]) => Promise<A[K]>;
+  };
+};
+
+type TypeMap = {
+  publicKey: PublicKey;
+  bool: boolean;
+  string: string;
+  bytes: Uint8Array;
+} & {
+  [K in 'u8' | 'i8' | 'u16' | 'i16' | 'u32' | 'i32']: number;
+} & {
+  [K in 'u64' | 'i64' | 'u128' | 'i128']: BN;
+};
+
+type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
+  ? TypeMap[T]
+  : T extends { defined: keyof Defined }
+  ? Defined[T['defined']]
+  : T extends { option: { defined: keyof Defined } }
+  ? Defined[T['option']['defined']] | null
+  : T extends { option: keyof TypeMap }
+  ? TypeMap[T['option']] | null
+  : T extends { vec: { defined: keyof Defined } }
+  ? Defined[T['vec']['defined']][]
+  : T extends { vec: keyof TypeMap }
+  ? TypeMap[T['vec']][]
+  : T extends { array: [idlType: keyof TypeMap, size: number] }
+  ? TypeMap[T['array'][0]][]
+  : unknown;
+
+type MakeArgs<A extends IdlField[], Defined> = {
+  [K in keyof A]: A[K] extends IdlField
+    ? DecodeType<A[K]['type'], Defined>
+    : unknown;
+};
+
+type MakeNamedArgs<A extends IdlField, Defined> = {
+  [K in A['name']]: DecodeType<(A & { name: K })['type'], Defined>;
+};
+
+type MakeInstructions<I extends IdlInstruction[], Defined> = {
+  [K in I[number]['name']]: {
+    accounts: (I[number] & { name: K })['accounts'];
+    args: MakeArgs<(I[number] & { name: K })['args'], Defined> & unknown[];
+    namedArgs: MakeNamedArgs<
+      (I[number] & { name: K })['args'][number],
+      Defined
+    >;
+  };
+};
+
+export type AnchorProgram<
+  IDL extends Idl,
+  A,
+  Defined = AnchorDefined<IDL>,
+  RPCInstructions extends MakeInstructions<
+    IDL['instructions'],
+    Defined
+  > = MakeInstructions<IDL['instructions'], Defined>,
+  Methods extends MakeInstructions<
+    NonNullable<IDL['state']>['methods'],
+    Defined
+  > = MakeInstructions<NonNullable<IDL['state']>['methods'], Defined>
+> = Omit<
+  AProgram,
+  'rpc' | 'state' | 'account' | 'transaction' | 'instruction'
+> & {
+  rpc: RpcNamespace<RPCInstructions>;
+  state: StateClient<IDL>;
+  account: AccountsNamespace<A>;
+  transaction: TransactionNamespace<RPCInstructions & Methods>;
+  instruction: InstructionNamespace<RPCInstructions & Methods>;
+};
+
+export type AnchorError<T extends Idl> = NonNullable<T['errors']>[number];
+
+type FieldsOfType<I extends IdlTypeDef> = I extends {
+  type: IdlTypeDefTyStruct;
+}
+  ? NonNullable<I['type']['fields']>[number]
+  : never;
+
+type AnchorTypeDef<I extends IdlTypeDef, Defined> = {
+  [F in FieldsOfType<I>['name']]: DecodeType<
+    (FieldsOfType<I> & { name: F })['type'],
+    Defined
+  >;
+};
+
+type AnchorTypeDefs<T extends IdlTypeDef[], Defined> = {
+  [K in T[number]['name']]: AnchorTypeDef<T[number] & { name: K }, Defined>;
+};
+
+export type AnchorDefined<
+  T extends Idl,
+  D = Record<string, never>
+> = AnchorTypeDefs<NonNullable<T['types']>, D>;
+
+export type AnchorAccounts<T extends Idl, Defined> = AnchorTypeDefs<
+  NonNullable<T['accounts']>,
+  Defined
+>;
+
+export type AnchorState<T extends Idl, Defined> = AnchorTypeDef<
+  NonNullable<T['state']>['struct'],
+  Defined
+>;
+
+export type AnchorTypes<
+  T extends Idl,
+  AccountMap = Record<string, never>,
+  D = Record<string, never>,
+  DEF = AnchorDefined<T, D>
+> = {
+  Defined: DEF;
+  Accounts: AnchorAccounts<T, DEF>;
+  State: AnchorState<T, DEF>;
+  Error: AnchorError<T>;
+  Program: AnchorProgram<T, AccountMap, DEF>;
+  Instructions: MakeInstructions<T['instructions'], DEF>;
+  Methods: MakeInstructions<NonNullable<T['state']>['methods'], DEF>;
+  Events: AnchorEvents<NonNullable<T['events']>[number], DEF>;
+  AccountMap: AccountMap;
+  IDL: T;
+};
+
+type AnchorEvent<T extends IdlEventField, Defined> = {
+  [N in T['name']]: DecodeType<(T & { name: N })['type'], Defined>;
+};
+
+type AnchorEvents<T extends IdlEvent, Defined> = {
+  [K in T['name']]: {
+    name: K;
+    data: AnchorEvent<(T & { name: K })['fields'][number], Defined>;
+  };
+};

--- a/src/factions.ts
+++ b/src/factions.ts
@@ -4,7 +4,7 @@ import {
   Program,
   web3
 } from '@project-serum/anchor';
-import { AnchorTypes } from '@saberhq/anchor-contrib';
+import { AnchorTypes } from './anchor/types';
 
 export type FactionEnlistment = {
   'version': '0.0.0',

--- a/src/marketplace/types/marketplace_accounts.ts
+++ b/src/marketplace/types/marketplace_accounts.ts
@@ -1,5 +1,5 @@
 import { web3 } from '@project-serum/anchor';
-import type { AnchorTypes } from '@saberhq/anchor-contrib';
+import type { AnchorTypes } from '../../anchor/types';
 export interface MarketVarsInfo {
 updateAuthorityMaster: web3.PublicKey,
 }

--- a/src/score.ts
+++ b/src/score.ts
@@ -5,7 +5,7 @@ import {
   Program,
   web3
 } from '@project-serum/anchor'
-import type { AnchorTypes } from '@saberhq/anchor-contrib';
+import type { AnchorTypes } from './anchor/types';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, Token } from '@solana/spl-token'
 import { SystemProgram } from '@solana/web3.js';
 import { getPlayerFactionPDA } from '.';


### PR DESCRIPTION
## Changes

This PR adds a "types" module for Anchor that has been entirely taken from the excellent [anchor-contrib](https://github.com/saber-hq/saber-common/tree/master/packages/anchor-contrib)

I chose to house just this code here because the development pace of anchor-contrib
and its dependencies kept breaking our tests.  Since we only use `AnchorTypes` from
that package, I decided to temporarily reference it here.

## Checklist

- [ ] UAT
- [ ] Passes final QA checks
