### PR TITLE
fix: set GM logs IDL metadata safely

### DIFF
--- a/src/marketplace/utils/getMarketplaceProgram.ts
+++ b/src/marketplace/utils/getMarketplaceProgram.ts
@@ -29,9 +29,13 @@ export function getGmIDL(
  */
 export function getGmLogsIDL(
     programId: web3.PublicKey
-): unknown {
+): Idl {
     const _tmp = gmLogsIdl.baseIdl;
-    _tmp['metadata']['address'] = programId.toBase58();
+    
+    _tmp['metadata'] = {
+        address: programId.toBase58(),
+    };
+
     return _tmp;
 }
 


### PR DESCRIPTION
## Changes

- Safely set `gmLogsIdl.metadata`
- Set return type of `getGmLogsIDL` to `Idl`

## Checklist

- [ ] UAT
- [ ] Passes final QA checks
