### PR TITLE
fix: hardcoded faction enlistment program ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staratlas/factory",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@staratlas/factory",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "ISC",
       "dependencies": {
         "@project-serum/anchor": "^0.24.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staratlas/factory",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@staratlas/factory",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
         "@project-serum/anchor": "^0.24.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staratlas/factory",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Star Atlas Factory for constructing Transactions targeting Solana on-chain programs",
   "repository": {
     "type": "git",

--- a/src/score.ts
+++ b/src/score.ts
@@ -8,10 +8,6 @@ import { scoreLogBaseIdl } from './util/scoreLogIdl';
 import { getTokenAccount } from './util';
 import * as SCORE_TYPES from './util/scoreIdl';
 
-const factionProgramId = new web3.PublicKey(
-  'FACTNmq2FhA2QNTnGM2aWJH3i7zT3cND5CgvjYTjyVYe'
-);
-
 export type SCORE_PROGRAM = SCORE_TYPES.Score;
 export type ScoreTypes = AnchorTypes<SCORE_PROGRAM>;
 type Account = ScoreTypes['Accounts'];
@@ -565,7 +561,10 @@ export async function createInitialDepositInstruction(
   shipQuantity: number,
   shipMint: web3.PublicKey,
   shipTokenAccount: web3.PublicKey,
-  programId: web3.PublicKey
+  programId: web3.PublicKey,
+  factionEnlistmentProgramId: web3.PublicKey = new web3.PublicKey(
+    'FACTNmq2FhA2QNTnGM2aWJH3i7zT3cND5CgvjYTjyVYe'
+  )
 ): Promise<web3.TransactionInstruction> {
   const [escrowAuthority, escrowAuthBump] = await getScoreEscrowAuthAccount(
     programId,
@@ -587,7 +586,7 @@ export async function createInitialDepositInstruction(
     await getScoreVarsShipAccount(programId, shipMint);
   const [playerFactionPDA] = await getPlayerFactionPDA(
     playerPublicKey,
-    factionProgramId
+    factionEnlistmentProgramId
   );
 
   const idl = getScoreIDL(programId);


### PR DESCRIPTION
## Changes

- Adds optional paramater to `createInitialDepositInstruction` to pass in the faction enlistment program ID, defaulting to `mainnet`