### PR TITLE
fix: do not use 'recent' commitment (#229)

### DIFF
--- a/src/marketplace/services/GmClientService.ts
+++ b/src/marketplace/services/GmClientService.ts
@@ -56,10 +56,7 @@ export class GmClientService {
 
     for (const info of currencyInfo) {
       const { mint, royalty, saVault } = info;
-      const tokenSupplylInformation = await connection.getTokenSupply(
-        mint,
-        'recent',
-      );
+      const tokenSupplylInformation = await connection.getTokenSupply(mint);
 
       const { decimals } = tokenSupplylInformation.value;
 

--- a/src/util/scoreHelpers.ts
+++ b/src/util/scoreHelpers.ts
@@ -258,10 +258,7 @@ export async function confirmTokenBalance(
   expectedQuantity: number,
   confirmClosed?: boolean,
 ) {
-  const tokenData = await provider.connection.getAccountInfo(
-    tokenAccount,
-    'recent',
-  );
+  const tokenData = await provider.connection.getAccountInfo(tokenAccount);
 
   // Confirm account is closed
   if (confirmClosed === true) {


### PR DESCRIPTION
This pull request includes changes to streamline the interaction with the `connection` object by removing the `'recent'` parameter from method calls in two files. The most important changes are:

Code simplification:

* [`src/marketplace/services/GmClientService.ts`](diffhunk://#diff-824033d47fd6c2eb07ae51fe0220e6167075384454afdd576de6f8e42a85a78bL59-R59): Removed the `'recent'` parameter from the `getTokenSupply` method call in the `GmClientService` class.
* [`src/util/scoreHelpers.ts`](diffhunk://#diff-0b693936c8c86d96f426c98382077c5aacbd8dbdac9df3e9a3509b7edde96bc2L261-R261): Removed the `'recent'` parameter from the `getAccountInfo` method call in the `confirmTokenBalance` function.## Changes

## Checklist

- [ ] UAT
- [ ] Passes final QA checks
